### PR TITLE
Bump version to 4.0.0-pre.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "curve25519-dalek"
 # - update html_root_url
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.0.0-pre.0"
+version = "4.0.0-pre.1"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ make doc-internal
 To import `curve25519-dalek`, add the following to the dependencies section of
 your project's `Cargo.toml`:
 ```toml
-curve25519-dalek = "4.0.0-pre.0"
+curve25519-dalek = "4.0.0-pre.1"
 ```
 
 ## Major Version API Changes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![deny(missing_docs)]
 
 #![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
-#![doc(html_root_url = "https://docs.rs/curve25519-dalek/4.0.0-pre.0")]
+#![doc(html_root_url = "https://docs.rs/curve25519-dalek/4.0.0-pre.1")]
 
 //! # curve25519-dalek [![](https://img.shields.io/crates/v/curve25519-dalek.svg)](https://crates.io/crates/curve25519-dalek) [![](https://img.shields.io/badge/dynamic/json.svg?label=docs&uri=https%3A%2F%2Fcrates.io%2Fapi%2Fv1%2Fcrates%2Fcurve25519-dalek%2Fversions&query=%24.versions%5B0%5D.num&colorB=4F74A6)](https://doc.dalek.rs) [![](https://travis-ci.org/dalek-cryptography/curve25519-dalek.svg?branch=master)](https://travis-ci.org/dalek-cryptography/curve25519-dalek)
 //!
@@ -66,7 +66,7 @@
 //! To import `curve25519-dalek`, add the following to the dependencies section of
 //! your project's `Cargo.toml`:
 //! ```toml
-//! curve25519-dalek = "3"
+//! curve25519-dalek = "4.0.0-pre.1"
 //! ```
 //!
 //! The sole breaking change in the `3.x` series was an update to the `digest`


### PR DESCRIPTION
This bumps the crate version on the release/4.0 branch to 4.0.0-pre.1 so it can be more easily targeted via cargo patching.