### PR TITLE
Update digest and sha2 versions to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "curve25519-dalek"
 # - update html_root_url
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.0.0-pre.0"
+version = "4.0.0-pre.2"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"
@@ -31,10 +31,10 @@ features = ["nightly", "simd_backend"]
 travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
 
 [dev-dependencies]
-sha2 = { version = "0.9", default-features = false }
-bincode = "1"
-criterion = "0.3.0"
-hex = "0.4.2"
+sha2 = { version = "0.10", default-features = false }
+bincode = "1.3.3"
+criterion = "0.3.5"
+hex = "0.4.3"
 rand = "0.8"
 
 [[bench]]
@@ -44,7 +44,7 @@ harness = false
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
-digest = { version = "0.9", default-features = false }
+digest = { version = "0.10", default-features = false }
 subtle = { version = "^2.2.1", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # The original packed_simd package was orphaned, see

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -613,6 +613,7 @@ impl Scalar {
     /// ```
     /// # extern crate curve25519_dalek;
     /// # use curve25519_dalek::scalar::Scalar;
+    /// # use curve25519_dalek::digest::Update;
     /// extern crate sha2;
     ///
     /// use sha2::Digest;


### PR DESCRIPTION
Also update `bincode`, `criterion` and `hex`, but those are minor.

Supports https://github.com/mobilecoinfoundation/mobilecoin/issues/1326